### PR TITLE
Add rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,20 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang noet
+
+
+%% Require at least R14B03. (couchdb requires this version or newer, and this code hasn't been tested on earlier)
+{require_min_otp_vsn, "R14B03"}.
+
+%% Ensure the ebin directory exists before we try to put files there.
+{pre_hooks, [
+    {compile, "mkdir -p ebin"}
+]}.
+
+
+%% == xref ==
+
+%% Enable xref warnings.
+{xref_warnings, true}.
+
+%% xref checks to run
+{xref_checks, [undefined_function_calls]}.


### PR DESCRIPTION
So that tools (e.g. Elixir Mix) can compile this as a dependency without hassle. `rebar.config` is taken as is from https://github.com/basho/erlang-pbkdf2/blob/7076584f5377e98600a7e2cb81980b2992fb2f71/rebar.config.